### PR TITLE
rclone: update to 1.56.0

### DIFF
--- a/srcpkgs/rclone/template
+++ b/srcpkgs/rclone/template
@@ -1,6 +1,6 @@
 # Template file for 'rclone'
 pkgname=rclone
-version=1.55.1
+version=1.56.0
 revision=1
 wrksrc="rclone-v${version}"
 build_style=go
@@ -13,9 +13,7 @@ license="MIT"
 homepage="https://rclone.org/"
 changelog="https://raw.githubusercontent.com/rclone/rclone/master/docs/content/changelog.md"
 distfiles="https://downloads.rclone.org/v${version}/rclone-v${version}.tar.gz"
-checksum=25da7fc5c9269b3897f27b0d946919df595c6dda1b127085fda0fe32aa59d29d
-# tests fail on CI
-make_check=ci-skip
+checksum=81d2eda23ebaad0a355aab6ff030712470a42505b94c01c9bb5a9ead9168cedb
 
 pre_build() {
 	if [ "$CROSS_BUILD" ] && [ "$XBPS_TARGET_LIBC" = musl ]; then
@@ -27,6 +25,9 @@ pre_build() {
 }
 
 do_check() {
+	rm cmd/serve/docker/docker_test.go
+
+	# equivalent to quicktest target of Makefile
 	RCLONE_CONFIG="/notfound" go test ./...
 }
 


### PR DESCRIPTION
- re-enable tests on ci
- pass $go_build_tags to `go test`
- disable tests for `rclone serve docker`

<!-- Mark items with [x] where applicable -->

#### General
- [ ] This is a new package and it conforms to the [quality requirements](https://github.com/void-linux/void-packages/blob/master/Manual.md#quality-requirements)

#### Have the results of the proposed changes been tested?
- [ ] I use the packages affected by the proposed changes on a regular basis and confirm this PR works for me
- [ ] I generally don't use the affected packages but briefly tested this PR

<!--
If GitHub CI cannot be used to validate the build result (for example, if the
build is likely to take several hours), make sure to
[skip CI](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#continuous-integration).
When skipping CI, uncomment and fill out the following section.
Note: for builds that are likely to complete in less than 2 hours, it is not
acceptable to skip CI.
-->
<!-- 
#### Does it build and run successfully? 
(Please choose at least one native build and, if supported, at least one cross build. More are better.)
- [ ] I built this PR locally for my native architecture, (ARCH-LIBC)
- [ ] I built this PR locally for these architectures (if supported. mark crossbuilds):
  - [ ] aarch64-musl
  - [ ] armv7l
  - [ ] armv6l-musl
-->
